### PR TITLE
feat: add relative direction text to look output (#21)

### DIFF
--- a/packages/town-cli/test/look-format.test.js
+++ b/packages/town-cli/test/look-format.test.js
@@ -1,0 +1,47 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { formatLook } = require('../../../shared/town-client/formatters');
+
+function createLookResult(overrides = {}) {
+  return {
+    player: {
+      x: 5,
+      y: 5,
+      zone: 'Town Center',
+      zoneDesc: 'Central square',
+      ...overrides.player,
+    },
+    nearby: overrides.nearby ?? [],
+  };
+}
+
+describe('formatLook', () => {
+  it('renders the empty nearby state without losing location text', () => {
+    const output = formatLook(createLookResult());
+
+    assert.match(output, /位置感知/);
+    assert.match(output, /\(5, 5\)/);
+    assert.match(output, /Town Center/);
+    assert.match(output, /Central square/);
+    assert.match(output, /四周空无一人/);
+    assert.doesNotMatch(output, /附近的人/);
+  });
+
+  it('preserves distance, zone, and message text while appending relative direction', () => {
+    const output = formatLook(createLookResult({
+      nearby: [
+        {
+          name: 'Alice',
+          distance: 2,
+          relativeDirection: '左前方',
+          zone: 'Town Center',
+          message: 'hello',
+        },
+      ],
+    }));
+
+    assert.match(output, /附近的人/);
+    assert.match(output, /Alice 距离你 2 步 \(位于 Town Center\)，在你的左前方，他正在说: "hello"/);
+  });
+});

--- a/packages/town-cli/test/smoke.test.js
+++ b/packages/town-cli/test/smoke.test.js
@@ -119,7 +119,7 @@ function createMockServer() {
           const session = tokens.get(auth);
           res.end(JSON.stringify({
             player: { x: 5, y: 5, zone: 'Town Center', zoneDesc: 'Central square', sprite: session.sprite, name: session.name },
-            nearby: [{ name: 'Alice', distance: 2, zone: 'Town Center', message: 'hello' }],
+            nearby: [{ name: 'Alice', distance: 2, relativeDirection: '左侧', zone: 'Town Center', message: 'hello' }],
           }));
           return;
         }
@@ -232,6 +232,7 @@ describe('Town CLI (smoke)', () => {
     const look = await runCli(['look'], env);
     assert.match(look.stdout, /位置感知/);
     assert.match(look.stdout, /Alice/);
+    assert.match(look.stdout, /左侧/);
 
     const walk = await runCli(['walk', '--direction', 'E', '--steps', '2'], env);
     assert.match(walk.stdout, /你试图向 E 走 2 步/);

--- a/server/src/engine/relative-direction.js
+++ b/server/src/engine/relative-direction.js
@@ -1,0 +1,39 @@
+function normalizeDelta(value) {
+  if (value > 0) return 1;
+  if (value < 0) return -1;
+  return 0;
+}
+
+function toRelativeAxes(dx, dy, facing = 'S') {
+  const stepX = normalizeDelta(dx);
+  const stepY = normalizeDelta(dy);
+
+  switch (facing) {
+    case 'N':
+      return { side: stepX, depth: -stepY };
+    case 'S':
+      return { side: -stepX, depth: stepY };
+    case 'E':
+      return { side: stepY, depth: stepX };
+    case 'W':
+      return { side: -stepY, depth: -stepX };
+    default:
+      return { side: -stepX, depth: stepY };
+  }
+}
+
+function describeRelativeDirection(dx, dy, facing = 'S') {
+  const { side, depth } = toRelativeAxes(dx, dy, facing);
+
+  if (side === 0 && depth === 0) return '附近';
+  if (depth > 0 && side < 0) return '左前方';
+  if (depth > 0 && side === 0) return '前方';
+  if (depth > 0 && side > 0) return '右前方';
+  if (depth === 0 && side < 0) return '左侧';
+  if (depth === 0 && side > 0) return '右侧';
+  if (depth < 0 && side < 0) return '左后方';
+  if (depth < 0 && side === 0) return '后方';
+  return '右后方';
+}
+
+module.exports = { describeRelativeDirection };

--- a/server/src/engine/world-engine.js
+++ b/server/src/engine/world-engine.js
@@ -4,6 +4,7 @@ const crypto = require('crypto');
 const { EventEmitter } = require('events');
 const { ZONE_INTERACTIONS, ZONE_CATEGORY_MAP } = require('../data/interactions');
 const { CHARACTER_SPRITES } = require('../data/characters');
+const { describeRelativeDirection } = require('./relative-direction');
 const {
   MESSAGE_TTL_MS,
   INTERACTION_TTL_MS,
@@ -474,6 +475,7 @@ function look(playerId) {
         id: other.id,
         name: other.name,
         distance,
+        relativeDirection: describeRelativeDirection(other.x - player.x, other.y - player.y, player.lastDirection),
         zone: other.currentZoneName,
         message: other.message || null,
         sprite: other.sprite,

--- a/server/test/smoke.test.js
+++ b/server/test/smoke.test.js
@@ -14,6 +14,7 @@ process.env.ALICIZATION_TOWN_TOKEN_TTL_MS = '1000';
 
 const MAP_PATH = path.join(__dirname, '..', 'web', 'assets', 'map.tmj');
 const worldEngine = require('../src/engine/world-engine');
+const { describeRelativeDirection } = require('../src/engine/relative-direction');
 
 function request(method, apiPath, body, headers = {}) {
   return new Promise((resolve, reject) => {
@@ -76,6 +77,29 @@ describe('World Engine (unit)', () => {
     assert.match(left.handle, /^at_[a-f0-9]{24}$/);
     assert.match(right.handle, /^at_[a-f0-9]{24}$/);
     assert.notEqual(left.handle, right.handle);
+  });
+
+  it('covers left/right/front/back and all diagonal relative directions', () => {
+    const cases = [
+      { dx: -1, dy: -1, facing: 'N', expected: '左前方' },
+      { dx: 0, dy: -1, facing: 'N', expected: '前方' },
+      { dx: 1, dy: -1, facing: 'N', expected: '右前方' },
+      { dx: -1, dy: 0, facing: 'N', expected: '左侧' },
+      { dx: 1, dy: 0, facing: 'N', expected: '右侧' },
+      { dx: -1, dy: 1, facing: 'N', expected: '左后方' },
+      { dx: 0, dy: 1, facing: 'N', expected: '后方' },
+      { dx: 1, dy: 1, facing: 'N', expected: '右后方' },
+    ];
+
+    for (const { dx, dy, facing, expected } of cases) {
+      assert.equal(describeRelativeDirection(dx, dy, facing), expected);
+    }
+  });
+
+  it('rotates relative direction with player facing', () => {
+    assert.equal(describeRelativeDirection(1, 0, 'S'), '左侧');
+    assert.equal(describeRelativeDirection(0, -1, 'E'), '左侧');
+    assert.equal(describeRelativeDirection(0, -1, 'W'), '右侧');
   });
 
 });

--- a/shared/town-client/formatters.js
+++ b/shared/town-client/formatters.js
@@ -54,6 +54,7 @@ function formatLook(result) {
   info += '👥 【附近的人】\n';
   nearby.forEach((person) => {
     info += `- ${person.name} 距离你 ${person.distance} 步 (位于 ${person.zone})`;
+    if (person.relativeDirection) info += `，在你的${person.relativeDirection}`;
     if (person.message) info += `，他正在说: "${person.message}"`;
     info += '\n';
   });


### PR DESCRIPTION
## Summary

This PR makes the smallest possible change for issue #21: it only adds relative direction text to the nearby people section of look output.

Examples of the new wording include:
- 左侧
- 右侧
- 前方
- 后方
- 左前方
- 右前方
- 左后方
- 右后方

## Scope

Included in this PR:
- add a small helper to convert coordinate deltas into relative direction text
- append relative direction text to each nearby person in look output
- keep existing distance / zone / message text intact
- add focused tests for direction mapping and final look formatting

Not included in this PR:
- no distance algorithm changes
- no location label changes
- no semantic perception expansion
- no coordinate abstraction or weakening
- no unrelated refactor

## Tests

Covered in this PR:
- left / right
- front / back
- all four diagonal directions
- empty nearby
- nearby person with message
- existing distance / zone wording remains intact

Commands run:
- 
ode --test --test-name-pattern="World Engine" server/test/smoke.test.js`n- 
ode --test packages/town-cli/test/look-format.test.js packages/town-cli/test/smoke.test.js`n