### PR TITLE
feat: 添加 /healthz 健康检查与运行时诊断端点

### DIFF
--- a/server/src/main.js
+++ b/server/src/main.js
@@ -67,4 +67,16 @@ io.on('connection', (socket) => {
   socket.emit('characterList', worldEngine.getCharacterList());
 });
 
+// ── 健康检查与运行时诊断 ──────────────────────────────────────────────────────
+app.get('/healthz', (_req, res) => {
+  res.json({
+    status: 'ok',
+    version: require('../package.json').version,
+    uptime: Math.floor(process.uptime()),
+    mapLoaded: worldEngine.getWorldMap() !== null,
+    playerCount: Object.keys(worldEngine.getAllPlayers()).length,
+    sseClients: sseClients.length,
+  });
+});
+
 server.listen(PORT, () => console.log(`🌍 Underworld 已启动: http://localhost:${PORT}`));


### PR DESCRIPTION
在 server/src/main.js 新增只读 GET /healthz 端点，
返回服务状态、版本号、运行时长、地图加载状态、
当前玩家数和 SSE 连接数，便于云端部署监控。

Closes #9