### PR TITLE
chore: align Node.js version requirement in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "socket.io-client": "^4.8.3"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22.5"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {


### PR DESCRIPTION
## 问题
package-lock.json 中的 engines 字段显示 "node": ">=18"，但 package.json 中实际需要 Node.js 22.5+

## 修改
将 package-lock.json 的 engines.node 更新为 ">=22.5"

## 验证
本地 `npm install` 正常运行

## 风险
极低，仅修改 engines 字段

## 向后兼容
是