### PR TITLE
fix: add action lock to look route for consistency

### DIFF
--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -68,10 +68,13 @@ router.post('/logout', (req, res) => {
   res.json({ ok: true });
 });
 
-router.get('/look', requireSession, (req, res) => {
-  const result = worldEngine.look(req.requestHandle.playerId);
-  if (!result) return res.status(404).json({ error: '玩家不存在' });
-  res.json({ ...result, perceptions: req.drainPerceptions(), newMessages: req.drainNewMessages() });
+router.get('/look', requireSession, async (req, res) => {
+  const release = await actionLock.acquire(req.requestHandle.playerId);
+  try {
+    const result = worldEngine.look(req.requestHandle.playerId);
+    if (!result) return res.status(404).json({ error: '玩家不存在' });
+    res.json({ ...result, perceptions: req.drainPerceptions(), newMessages: req.drainNewMessages() });
+  } finally { release(); }
 });
 
 router.post('/walk', requireSession, async (req, res) => {


### PR DESCRIPTION
## Summary

The walk, chat, interact routes already use actionLock to prevent concurrent actions from the same agent. This adds the same protection to the look route for consistency.

## Changes

- Added `await actionLock.acquire(req.requestHandle.playerId)` to the look route
- Properly releases lock in finally block

## Context

This addresses issue #36 about chained walk/look/interact causing position desync. While the core action lock was already implemented in the upstream develop branch, the look route was missing this protection.