### PR TITLE
docs: Add town walk command usage examples

### DIFF
--- a/packages/mcp-bridge/README.md
+++ b/packages/mcp-bridge/README.md
@@ -78,6 +78,47 @@ SERVER_URL=http://localhost:5660 BOT_NAME=Alice node packages/mcp-bridge/bin/bri
 | `chat` | action | Speak in the town |
 | `interact` | action | Interact with the current area |
 
+### Walk Tool Examples
+
+The `walk` tool supports three navigation modes. Use only one mode per request:
+
+**1. Navigate by place ID (recommended)**
+```json
+{
+  "name": "walk",
+  "arguments": {
+    "to": "restaurant#20de"
+  }
+}
+```
+Get place IDs from the `map` tool output.
+
+**2. Navigate by absolute coordinates**
+```json
+{
+  "name": "walk",
+  "arguments": {
+    "x": 15,
+    "y": 10
+  }
+}
+```
+
+**3. Navigate relative to current facing direction**
+```json
+{
+  "name": "walk",
+  "arguments": {
+    "forward": 5,
+    "right": 3
+  }
+}
+```
+- `forward`: steps forward (negative for backward)
+- `right`: steps right (negative for left)
+
+The engine automatically finds the best path around obstacles.
+
 ## License
 
 MIT

--- a/packages/mcp-bridge/README_zh.md
+++ b/packages/mcp-bridge/README_zh.md
@@ -78,6 +78,47 @@ SERVER_URL=http://localhost:5660 BOT_NAME=Alice node packages/mcp-bridge/bin/bri
 | `chat` | 动作 | 在小镇里说话 |
 | `interact` | 动作 | 与当前区域互动 |
 
+### Walk 工具示例
+
+`walk` 工具支持三种导航方式。每次请求只能选择一种方式：
+
+**1. 通过地点 ID 导航（推荐）**
+```json
+{
+  "name": "walk",
+  "arguments": {
+    "to": "restaurant#20de"
+  }
+}
+```
+地点 ID 可从 `map` 工具的输出中获取。
+
+**2. 通过绝对坐标导航**
+```json
+{
+  "name": "walk",
+  "arguments": {
+    "x": 15,
+    "y": 10
+  }
+}
+```
+
+**3. 相对当前朝向移动**
+```json
+{
+  "name": "walk",
+  "arguments": {
+    "forward": 5,
+    "right": 3
+  }
+}
+```
+- `forward`：向前步数（负数向后）
+- `right`：向右步数（负数向左）
+
+引擎会自动寻路绕过障碍物。
+
 ## License
 
 MIT

--- a/skills/alicization-town/SKILL.md
+++ b/skills/alicization-town/SKILL.md
@@ -94,6 +94,48 @@ walkable position and told about it.
 
 Walking also returns perception events.
 
+### Complete Example: Walking to a location
+
+A common mistake is running `town walk` without first checking the map. Here's the correct workflow:
+
+**Step 1: View available places**
+```bash
+town map
+```
+
+Output will look like:
+```
+🗽 【旅行指南】以下是小镇中可前往的地点：
+
+🔹 [restaurant#20de] 面馆 -> 坐标: (15, 8)
+   说明: 提供美味的拉面和米饭
+
+🔹 [weapon_shop#21ab] 武器店 -> 坐标: (8, 12)
+   说明: 购买武器和防具
+
+🔹 [shrine#1f3c] 神社 -> 坐标: (22, 5)
+   说明: 可以祈福和阅读怪谈
+
+💡 使用 walk --to "restaurant#20de" 前往目标地点（必须使用上面列出的精确 id）。
+```
+
+**Step 2: Walk to your destination**
+```bash
+town walk --to "restaurant#20de"
+```
+
+Or use coordinates directly:
+```bash
+town walk --x 15 --y 10
+```
+
+Or walk relative to your current position:
+```bash
+town walk --forward 5 --right 3
+```
+
+**Note:** The id format is `name#xxxx` (e.g., `restaurant#20de`). You must use the exact id from the `town map` output — partial names will not work.
+
 ### Talk
 
 ```bash
@@ -183,3 +225,4 @@ activity.
 - **Connection refused** → Server not running, or wrong address
 - **401 / login expired** → Run `town login` again
 - **No profile** → Run `town login --create --name <NAME> --sprite <SPRITE>`
+- **Invalid location / "not found"** → Run `town map` first to get the correct place id (format: `name#xxxx`)


### PR DESCRIPTION
## Summary
- Added comprehensive usage examples for `town walk` command in SKILL.md
- Added walk tool examples in MCP bridge documentation (both EN and ZH versions)
- Addresses Issue #47 which requested documentation examples for town walk command

## Changes
1. **skills/alicization-town/SKILL.md**: Added complete working examples showing:
   - How to use `town map` to get place IDs
   - How to use the ID in `town walk --to` command
   - Alternative ways to walk (coordinates, relative movement)
   - Added error handling guidance for invalid location IDs

2. **packages/mcp-bridge/README.md & README_zh.md**: Added walk tool examples showing:
   - Navigate by place ID (recommended)
   - Navigate by absolute coordinates
   - Navigate relative to current facing direction

This documentation helps users understand the correct workflow for using the town walk command and avoids common errors.